### PR TITLE
make version argument to cinst use --version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ init:
   - git config --global core.autocrlf input
 
 install:
-  - cinst strawberryperl -version 5.20.1.1
+  - cinst strawberryperl --version 5.20.1.1
   - SET PATH=C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin;%PATH%
   - cpanm --installdeps --notest .
 


### PR DESCRIPTION
Should fix this in the appveyor logs:

cinst strawberryperl -version 5.20.1.1
Parsing -version resulted in exception:
 Cannot bundle unregistered option '-e'.

