### PR TITLE
Fix some leak-on-exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ names.txt
 bench/mandelbrot/mandelbrot.perl
 *.bin
 *.bin.hdr
+*.swp
+*.swo


### PR DESCRIPTION
See https://github.com/run4flat/C-Blocks/issues/10

This is a clean re-implementation of the commit I have in my threading-fix branch so that you can apply the memory leak fix to your master without the (partially broken) multi threading fixes.