### PR TITLE
Build and invoke custom OPs slightly more efficiently

### DIFF
--- a/lib/C/Blocks.xs
+++ b/lib/C/Blocks.xs
@@ -41,12 +41,24 @@ typedef struct _available_extended_symtab {
 
 XOP tcc_xop;
 PP(tcc_pp) {
-    dVAR;
-    dSP;
-	IV pointer_iv = POPi;
-	my_void_func p_to_call = INT2PTR(my_void_func, pointer_iv);
+	dSP;
+	void *ptr = INT2PTR(my_void_func, (UV)PL_op->op_targ);
+	my_void_func p_to_call = ptr;
 	p_to_call(aTHX);
 	RETURN;
+}
+
+Perl_ophook_t original_opfreehook;
+
+void
+op_free_hook(pTHX_ OP *o)
+{
+	if (original_opfreehook != NULL)
+		original_opfreehook(aTHX_ o);
+
+	if (o->op_ppaddr == Perl_tcc_pp) {
+		o->op_targ = 0; /* important or Perl will use it to access the pad */
+	}
 }
 
 #ifdef PERL_IMPLICIT_CONTEXT
@@ -1183,15 +1195,20 @@ OP * build_op(pTHX_ TCCState * state, int keyword_type) {
 	if (keyword_type != IS_CBLOCK) return newOP(OP_NULL, 0);
 	
 	/* get the function pointer for the block */
-	IV pointer_IV = PTR2IV(tcc_get_symbol(state, "op_func"));
-	if (pointer_IV == 0) {
+	void *sym_pointer = tcc_get_symbol(state, "op_func");
+	if (sym_pointer == NULL) {
 		croak("C::Blocks internal error: got null pointer for op function!");
 	}
 	
-	/* Store the address of the function pointer on the stack */
-	OP * o = newUNOP(OP_RAND, 0, newSVOP(OP_CONST, 0, newSViv(pointer_IV)));
-	
-	/* Create an op that pops the address off the stack and invokes it */
+	/* create new OP that gets the sym_pointer from its op_targ slot
+	 * and invokes it */
+	OP * o;
+	NewOp(1101, o, 1, OP);
+
+	o->op_type = (OPCODE)OP_CUSTOM;
+	o->op_private = 0;
+	o->op_flags = 0;
+	o->op_targ = (PADOFFSET)PTR2UV(sym_pointer);
 	o->op_ppaddr = Perl_tcc_pp;
 	
 	return o;
@@ -1513,6 +1530,10 @@ BOOT:
 	/* Set up the keyword plugin to a useful initial value. */
 	next_keyword_plugin = PL_keyword_plugin;
 	
+	/* Setup our callback for cleaning up OPs during global cleanup */
+	original_opfreehook = PL_opfreehook;
+	PL_opfreehook = op_free_hook;
+
 	my_mem_tail = my_mem_root = malloc(sizeof(executable_memory) + 16384);
 	my_mem_tail->curr_address = (uintptr_t)my_mem_tail->base_address;
 	my_mem_tail->bytes_remaining = 16384;
@@ -1527,4 +1548,6 @@ BOOT:
 	/* Set up the custom op */
 	XopENTRY_set(&tcc_xop, xop_name, "tccop");
 	XopENTRY_set(&tcc_xop, xop_desc, "Op to run jit-compiled C code");
+	XopENTRY_set(&tcc_xop, xop_class, OA_BASEOP);
+
 	Perl_custom_op_register(aTHX_ Perl_tcc_pp, &tcc_xop);


### PR DESCRIPTION
In a nutshell, this changes goes from executing two OPs (CONST puts
function pointer on stack, XOP pops it off and executes it) to a single
OP: We simply shove the function pointer into one of the unused struct
members, op_targ.

The normal purpose of op_targ (targ, short for target, sigh) is to store
an offset into the PADLIST for re-using SVs in the functions lexical
(scratch)pad for passing data between OPs instead of using the stack.
Because all the pushing, popping, and especially repeated SV allocation
comes at a cost.

That's the "t3" in the following example OP tree:

```
  $ perl -MO=Concise -e 'my $x = $_/2;'
  8  <@> leave[1 ref] vKP/REFC ->(end)
  1     <0> enter ->2
  2     <;> nextstate(main 1 -e:1) v:{ ->3
  7     <2> sassign vKS/2 ->8
  5        <2> divide[t3] sK/2 ->6
  -           <1> ex-rv2sv sK/1 ->4
  3              <#> gvsv[*_] s ->4
  4           <$> const[IV 2] s ->5
  6        <0> padsv[$x:1,2] sRM*/LVINTRO ->7
  -e syntax OK

```
It's kind of a cool optimization in perl, really. :)

The one gotcha is that perl normally helpfully frees the targeted
scratchpads, so we have to define an OP free hook that sets it to 0 to
prevent funny free's.

Forgot to mention what performance difference is. With this "benchmark":

```
use strict;
use warnings;

use C::Blocks;
for (1..1000000) {
  cblock {
    int i;
  }
}
```

I get this before:

```
~/perl/C-Blocks$ dumbbench -- perl -Mblib t.pl
cmd: Ran 21 iterations (1 outliers).
cmd: Rounded run time per iteration: 1.9377e-01 +/- 2.7e-04 (0.1%)
```

and this after:

```
~/perl/C-Blocks$ dumbbench -- perl -Mblib t.pl
cmd: Ran 21 iterations (1 outliers).
cmd: Rounded run time per iteration: 1.7744e-01 +/- 1.8e-04 (0.1%)
```