### PR TITLE
Use Perl_call_atexit to execute cleanup VERY late

### DIFF
--- a/lib/C/Blocks.pm
+++ b/lib/C/Blocks.pm
@@ -60,10 +60,6 @@ sub C::Blocks::load_lib {
 	$^H{"C::Blocks/extended_symtab_tables"} .= $symtab_list;
 }
 
-END {
-	_cleanup();
-}
-
 1;
 
 __END__


### PR DESCRIPTION
Perl_call_atexit is called AFTER all END blocks in Perl code are done.
That increases the likelihood of not encountering any crashing,
hard-to-debug bugs of the following variety to almost zero:

  use strict;use warnings;
  END { foo() }

  use C::Blocks;
  use C::Blocks::PerlAPI;

  sub foo { cblock {} }

Before this change, the above would rather reliably segfault. Now, it
executes just fine and there's also no leaks introduced.