### PR TITLE
Add failing TODO test for typed our() vars being interpolated

### DIFF
--- a/t/50-sigiled-vars.t
+++ b/t/50-sigiled-vars.t
@@ -113,4 +113,26 @@ eval q{
 	diag($@);
 };
 
+
+TODO: {
+	our $test_name = '"our $bar" gets detected as a package var';
+	local $TODO = "pad_find_my returns a pad slot for package vars declared with our() (it's an alias of sorts)";
+	unless(eval qq[
+			use C::Blocks::Types qw(double);
+			our double \$bar = 12;
+			cblock {
+				\$bar = 13;
+			}
+			is(\$bar, 13, '$::test_name: desired output');
+			1;
+		])
+	{
+		fail($test_name);
+		diag($@);
+	}
+	else {
+		pass($test_name);
+	}
+}
+
 done_testing;


### PR DESCRIPTION
pad_find_my returns a pad slot for variables declared with our(). That
means C::Blocks falls into the "this is a lexical" code path, which
_seems_ to fail.

My understanding is that our()-declared variables are essentially
aliases to the underlying package variable, implemented by creating a
PAD entry for them and just putting the SV pointer of the package var in
that. I think. That would explain the pad_find_my return but it would
suggest that the code SHOULD actually work, but it seems not to.

  use C::Blocks::Types qw(double);
  our double $bar = 12;
  cblock {
    $bar = 13;
  }
  is($bar, 13, 'desired output');

The above test fails in that $bar is still 12.

The C code generated for the above block is:

  void op_func(C_BLOCKS_THX_DECL) {
    SV * SV__PERL_SCALAR_bar = (SV*)PAD_SV(1);
    double _PERL_SCALAR_bar = SvNV(SV__PERL_SCALAR_bar);

    _PERL_SCALAR_bar = 13;

    sv_setnv(SV__PERL_SCALAR_bar, _PERL_SCALAR_bar);
  }

Which checks out on a superficial review PROVIDED THAT THE our()
MECHANISM WORKS THE WAY I THOUGHT! (Seems I'm wrong.)