### PR TITLE
Tsee/xs code split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-*.c
 *.o
 Build
 _build
@@ -14,3 +13,5 @@ bench/mandelbrot/mandelbrot.perl
 *.bin.hdr
 *.swp
 *.swo
+lib/C/Blocks.c
+lib/C/Blocks/PerlAPI.c

--- a/Build.PL
+++ b/Build.PL
@@ -35,9 +35,10 @@ my $build = Module::Build->new(
 		'File::ShareDir' => 0,
 		'File::Spec' => 0,
 	},
+        c_source => 'src',
 	needs_compiler => 1,
 	dynamic_config => 1,
-	include_dirs => [Alien::TinyCCx->libtcc_include_path, '.'],
+	include_dirs => [Alien::TinyCCx->libtcc_include_path, '.', 'src'],
 	extra_linker_flags => [Alien::TinyCCx->MB_linker_flags],
 	meta_merge => {
 		resources  => {

--- a/lib/C/Blocks.xs
+++ b/lib/C/Blocks.xs
@@ -30,6 +30,7 @@
 #define pad_compname_type(a)	Perl_pad_compname_type(aTHX_ a)
 #endif
 
+#include <cb_mem_mgmt.h>
 #include <cb_custom_op.h>
 
 
@@ -1253,44 +1254,7 @@ void serialize_symbol_table(pTHX_ TCCState * state, c_blocks_data * data, int ke
 	}
 }
 
-typedef struct executable_memory executable_memory;
-struct executable_memory {
-	uintptr_t curr_address;
-	uintptr_t bytes_remaining;
-	executable_memory * next;
-	char base_address[0];
-};
-executable_memory * my_mem_root;
-executable_memory * my_mem_tail;
 
-void * my_mem_alloc (size_t n_bytes) {
-	if (n_bytes > my_mem_tail->bytes_remaining) {
-		/* allocate requested plus 16K of memory */
-		my_mem_tail->next = malloc(sizeof(executable_memory) + n_bytes + 16384);
-		my_mem_tail = my_mem_tail->next;
-		my_mem_tail->curr_address = (uintptr_t)my_mem_tail->base_address;
-		my_mem_tail->bytes_remaining = n_bytes + 16384;
-		/* check alignment */
-		if ((my_mem_tail->curr_address & 63) != 0) {
-			my_mem_tail->curr_address &= ~63;
-			my_mem_tail->curr_address += 64;
-			my_mem_tail->bytes_remaining
-				-= my_mem_tail->curr_address - (uintptr_t)my_mem_tail->base_address;
-		}
-		my_mem_tail->next = 0;
-	}
-	void * to_return = (void*)my_mem_tail->curr_address;
-	
-	/* update and align curr_address */
-	my_mem_tail->curr_address += n_bytes;
-	if ((my_mem_tail->curr_address & 63) != 0) {
-		my_mem_tail->curr_address &= ~63;
-		my_mem_tail->curr_address += 64;
-	}
-	my_mem_tail->bytes_remaining
-		-= my_mem_tail->curr_address - (uintptr_t)to_return;
-	return to_return;
-}
 
 
 /* Global C::Blocks cleanup handler - executed using Perl_call_atexit. Any
@@ -1319,13 +1283,8 @@ void c_blocks_final_cleanup(pTHX_ void *ptr) {
 			warn("C::Blocks had trouble freeing dll list, index %d", i);
 		}
 	}
-	/* Remove all the code pages */
-	executable_memory * to_cleanup = my_mem_root;
-	while(to_cleanup) {
-		executable_memory * tmp = to_cleanup->next;
-		free(to_cleanup);
-		to_cleanup = tmp;
-	}
+
+	cb_mem_mgmt_cleanup();
 }
 
 
@@ -1385,7 +1344,7 @@ STATIC int _my_keyword_plugin(pTHX_ char *keyword_ptr,
 	sv_setiv(get_sv("C::Blocks::_last_machine_code_size", GV_ADD | GV_ADDMULTI),
 		machine_code_size);
 	if (machine_code_size > 0) {
-		void * machine_code = my_mem_alloc(machine_code_size);
+		void * machine_code = cb_mem_alloc(machine_code_size);
 #if 0
 		/* Add enough bytes to align on cache line size */
 		SV * machine_code_SV = newSV(machine_code_size + 63);
@@ -1501,17 +1460,7 @@ BOOT:
 	next_keyword_plugin = PL_keyword_plugin;
 	
         cb_init_custom_op(aTHX);
-
-	my_mem_tail = my_mem_root = malloc(sizeof(executable_memory) + 16384);
-	my_mem_tail->curr_address = (uintptr_t)my_mem_tail->base_address;
-	my_mem_tail->bytes_remaining = 16384;
-	if ((my_mem_tail->curr_address & 0x63) != 0) {
-		my_mem_tail->curr_address &= ~63;
-		my_mem_tail->curr_address += 64;
-		my_mem_tail->bytes_remaining
-			-= my_mem_tail->curr_address - (uintptr_t)my_mem_tail->base_address;
-	}
-	my_mem_tail->next = 0;
+	cb_mem_mgmt_init();
 	
         /* Register our cleanup handler to run as late as possible. */
         Perl_call_atexit(aTHX_ c_blocks_final_cleanup, NULL);

--- a/src/cb_custom_op.c
+++ b/src/cb_custom_op.c
@@ -1,0 +1,41 @@
+#include <cb_custom_op.h>
+
+XOP tcc_xop;
+
+typedef void (*my_void_func)(pTHX);
+
+PP(tcc_pp) {
+	dSP;
+	void *ptr = INT2PTR(my_void_func, (UV)PL_op->op_targ);
+	my_void_func p_to_call = ptr;
+	p_to_call(aTHX);
+	RETURN;
+}
+
+
+Perl_ophook_t original_opfreehook;
+
+static void
+op_free_hook(pTHX_ OP *o) {
+	if (original_opfreehook != NULL)
+		original_opfreehook(aTHX_ o);
+
+	if (o->op_ppaddr == Perl_tcc_pp) {
+		o->op_targ = 0; /* important or Perl will use it to access the pad */
+	}
+}
+
+
+void cb_init_custom_op(pTHX) {
+	/* Setup our callback for cleaning up OPs during global cleanup */
+	original_opfreehook = PL_opfreehook;
+	PL_opfreehook = op_free_hook;
+
+	/* Set up the custom op */
+	XopENTRY_set(&tcc_xop, xop_name, "tccop");
+	XopENTRY_set(&tcc_xop, xop_desc, "Op to run jit-compiled C code");
+	XopENTRY_set(&tcc_xop, xop_class, OA_BASEOP);
+
+	Perl_custom_op_register(aTHX_ Perl_tcc_pp, &tcc_xop);
+}
+

--- a/src/cb_custom_op.c
+++ b/src/cb_custom_op.c
@@ -25,6 +25,24 @@ op_free_hook(pTHX_ OP *o) {
 	}
 }
 
+OP * cb_build_op(pTHX_ void *sym_pointer) {
+	/* create new OP that gets the sym_pointer from its op_targ slot
+	 * and invokes it */
+	OP * o;
+	NewOp(1101, o, 1, OP);
+
+	o->op_type = (OPCODE)OP_CUSTOM;
+	o->op_next = (OP*)o;
+	o->op_private = 0;
+	o->op_flags = 0;
+	o->op_targ = (PADOFFSET)PTR2UV(sym_pointer);
+	o->op_ppaddr = Perl_tcc_pp;
+	
+	return o;
+}
+
+
+
 
 void cb_init_custom_op(pTHX) {
 	/* Setup our callback for cleaning up OPs during global cleanup */

--- a/src/cb_custom_op.h
+++ b/src/cb_custom_op.h
@@ -9,7 +9,8 @@
 
 extern XOP tcc_xop;
 
-PP(tcc_pp);
+/* Create a new OP that'll execute the given symbol pointer. */
+OP * cb_build_op(pTHX_ void *sym_pointer);
 
 /* Sets up the global state related to our custom OP(s).
  * To be called once before using any of them (eg. BEGIN time of C::Blocks) */

--- a/src/cb_custom_op.h
+++ b/src/cb_custom_op.h
@@ -1,0 +1,19 @@
+#ifndef CB_CUSTOM_OP_H_
+#define CB_CUSTOM_OP_H_
+
+/* Logic related to implementing, creating, and managing the C::Blocks
+ * custom ops. */
+
+#include <EXTERN.h>
+#include <perl.h>
+
+extern XOP tcc_xop;
+
+PP(tcc_pp);
+
+/* Sets up the global state related to our custom OP(s).
+ * To be called once before using any of them (eg. BEGIN time of C::Blocks) */
+void cb_init_custom_op(pTHX);
+
+
+#endif

--- a/src/cb_mem_mgmt.c
+++ b/src/cb_mem_mgmt.c
@@ -1,0 +1,65 @@
+#include <cb_mem_mgmt.h>
+
+typedef struct executable_memory executable_memory;
+struct executable_memory {
+	uintptr_t curr_address;
+	uintptr_t bytes_remaining;
+	executable_memory * next;
+	char base_address[0];
+};
+
+executable_memory * my_mem_root;
+executable_memory * my_mem_tail;
+
+void *cb_mem_alloc(size_t n_bytes) {
+	if (n_bytes > my_mem_tail->bytes_remaining) {
+		/* allocate requested plus 16K of memory */
+		my_mem_tail->next = malloc(sizeof(executable_memory) + n_bytes + 16384);
+		my_mem_tail = my_mem_tail->next;
+		my_mem_tail->curr_address = (uintptr_t)my_mem_tail->base_address;
+		my_mem_tail->bytes_remaining = n_bytes + 16384;
+		/* check alignment */
+		if ((my_mem_tail->curr_address & 63) != 0) {
+			my_mem_tail->curr_address &= ~63;
+			my_mem_tail->curr_address += 64;
+			my_mem_tail->bytes_remaining
+				-= my_mem_tail->curr_address - (uintptr_t)my_mem_tail->base_address;
+		}
+		my_mem_tail->next = 0;
+	}
+	void * to_return = (void*)my_mem_tail->curr_address;
+	
+	/* update and align curr_address */
+	my_mem_tail->curr_address += n_bytes;
+	if ((my_mem_tail->curr_address & 63) != 0) {
+		my_mem_tail->curr_address &= ~63;
+		my_mem_tail->curr_address += 64;
+	}
+	my_mem_tail->bytes_remaining
+		-= my_mem_tail->curr_address - (uintptr_t)to_return;
+	return to_return;
+}
+
+void cb_mem_mgmt_init() {
+	my_mem_tail = my_mem_root = malloc(sizeof(executable_memory) + 16384);
+	my_mem_tail->curr_address = (uintptr_t)my_mem_tail->base_address;
+	my_mem_tail->bytes_remaining = 16384;
+	if ((my_mem_tail->curr_address & 0x63) != 0) {
+		my_mem_tail->curr_address &= ~63;
+		my_mem_tail->curr_address += 64;
+		my_mem_tail->bytes_remaining
+			-= my_mem_tail->curr_address - (uintptr_t)my_mem_tail->base_address;
+	}
+	my_mem_tail->next = 0;
+}
+
+void cb_mem_mgmt_cleanup() {
+	/* Remove all the code pages */
+	executable_memory * to_cleanup = my_mem_root;
+	while(to_cleanup) {
+		executable_memory * tmp = to_cleanup->next;
+		free(to_cleanup);
+		to_cleanup = tmp;
+	}
+}
+

--- a/src/cb_mem_mgmt.h
+++ b/src/cb_mem_mgmt.h
@@ -1,0 +1,19 @@
+#ifndef CB_MEM_MGMT_H_
+#define CB_MEM_MGMT_H_
+
+/* Logic related to implementing, creating, and managing the C::Blocks
+ * custom ops. */
+
+#include <EXTERN.h>
+#include <perl.h>
+
+void *cb_mem_alloc(size_t n_bytes);
+
+/* Needs to be called before using C::Blocks to initialize the
+ * executable_memory state. */
+void cb_mem_mgmt_init();
+/* Needs to be called during global destruction to free the
+ * executable_memory state. */
+void cb_mem_mgmt_cleanup();
+
+#endif


### PR DESCRIPTION
This implements a start of what I'm musing about in https://github.com/run4flat/C-Blocks/issues/19

In a nutshell, this moves the custom OP logic to its own source file as well as the executable memory bit.

I think the "extract C code" / parsing logic can/should go into its own thing but I ran out of time and IIRC it's not a clean parser/lexer in the sense that there's actions taken/code being generated on the basis of the parse already there. That makes a bit murky to extract. Anyway - code style preferences I suppose.