### PR TITLE
Fix keyword scoping implementation

### DIFF
--- a/lib/C/Blocks.pm
+++ b/lib/C/Blocks.pm
@@ -30,8 +30,17 @@ sub import {
 	*{$caller.'::csub'} = sub () {};
 	*{$caller.'::cshare'} = sub () {};
 	*{$caller.'::clex'} = sub () {};
-	_import();
+
+	# Enable keywords in lexical scope ("C::Blocks/keywords" isn't
+	# a magical choice of hints hash entry, it just needs to match XS)
+	$^H{"C::Blocks/keywords"} = 1;
 }
+
+sub unimport {
+	# and disable keywords!
+	delete $^H{"C::Blocks/keywords"};
+}
+
 
 # Provided so I can call warnings::warnif from Blocks.xs. Why can't I
 # just call warnings::warnif from that code directly????  XXX

--- a/t/22-keyword-scoping.t
+++ b/t/22-keyword-scoping.t
@@ -1,0 +1,32 @@
+# This tests the import/unimport lexical behavior of the C::Blocks keywords.
+
+use strict;
+use warnings;
+use Test::More tests => 3;
+
+SCOPE: {
+	use C::Blocks;
+	ok(
+		eval q[cblock { int i; } 1],
+		"Compiled C block within C::Blocks scope"
+	);
+	SCOPE: {
+		no C::Blocks;
+		local $SIG{__WARN__} = sub {};
+		ok(
+			!eval q[cblock { int i; } 1],
+			"Expectedly failed to compile C block within 'no C::Blocks' scope"
+		);
+	}
+}
+
+
+local $SIG{__WARN__} = sub {};
+ok(
+	!eval q[cblock { int i; } 1],
+	"Expectedly failed to compile C block outside C::Blocks scope"
+);
+
+
+
+


### PR DESCRIPTION
The logic for this is borrowed from PLua: In a nutshell, we install our
keyword plugin handler into the chain of keyword plugins globally and
permanently, and then we use the hints hash system to dynamically modify
whether or not we're actually APPLYING our keyword handler in practice.

Doing this another way seems to be infeasible because you'd otherwise
have to have a way to go through the entire chain of keyword handlers
and plucking out this one in the unimport. Otherwise, this module can
never work with any other keyword plugin (globally).